### PR TITLE
fix runtime error due to comparison (<) and NaN's on line 452 of segment_models.py

### DIFF
--- a/pyppluss/segment_models.py
+++ b/pyppluss/segment_models.py
@@ -449,7 +449,11 @@ def integrate_swapped(n_center,n_gress,radius_planet, radius_in, radius_out, x_p
 
     #Ensure all splitr values are on the interval [0,rcrit]
     #Check whether there are points beyond one - whether there is a interval [a,rcrit] which requires numerical integration
-    todo_start = np.all(np.logical_or(splitr[:,2:]<rcrit,np.isnan(splitr[:,2:])),-1)
+    splitr_decider = np.zeros_like(splitr[:,2:]).astype(np.bool)
+    splitr_decider[np.isnan(splitr[:,2:])] = True
+    splitr_decider[~np.isnan(splitr[:,2:])] = splitr[:,2:][~np.isnan(splitr[:,2:])] < rcrit
+    todo_start = np.all(splitr_decider, -1)
+    #todo_start = np.all(np.logical_or(splitr[:,2:]<rcrit,np.isnan(splitr[:,2:])),-1)
     splitr[np.isnan(splitr)] = rcrit
     splitr[splitr>1] = rcrit
     splitr[splitr<0] = rcrit


### PR DESCRIPTION
added splitr_decider (please rename accordingly) to replace the statement inside the np.all() statement attached to the v
ariable todo_start on the original line 452. this has been done to prevent runtime errors caused by -- splitr[:,2:]<rcrit, wh
ere splitr[:,2:] contains NaNs